### PR TITLE
Rake task to populate from cloned PatternLab repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ override the gem's `app/views/templates/Search/Search-results-list.mustache`
 template, copy it to `$RAILS_ROOT/app/views/templates/Search/Search-results-list.mustache`
 and edit as required.
 
+#### Updating templates
+
+If you also have the [Europeana-Patternlab](https://github.com/europeana/Europeana-Patternlab)
+repository cloned and want to use it to populate view templates and other assets
+in your clone of europeana-styleguide-ruby, for instance to test a feature branch
+of the PatternLab repository, use the supplied Rake task:
+```
+bundle exec rake europeana_styleguide:populate[../Europeana-Patternlab]
+```
+... assuming that the cloned PatternLab repository is in the directory 
+`../Europeana-Patternab`.
+
 ### View classes
 
 Data is supplied to the Mustache templates for variable placeholder expansion via

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,5 @@
 # frozen_string_literal: true
+
+Dir['lib/tasks/*.rake'].each { |rake| load rake }
+
 require 'bundler/gem_tasks'

--- a/lib/tasks/europeana_styleguide.rake
+++ b/lib/tasks/europeana_styleguide.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+namespace :europeana_styleguide do
+  desc 'Copy views & assets from cloned europeana/Europeana-Patternlab repo.'
+  task :populate, [:patternlab_path] do |_task, args|
+    gem_dir = File.expand_path('../..', __dir__)
+    patternlab_dir = File.expand_path(args[:patternlab_path], Dir.pwd)
+
+    %w(app/views app/assets/stylesheets app/assets/javascripts app/assets/images).each do |path|
+      rm_dir = "#{gem_dir}/#{path}"
+      print "Deleting #{rm_dir}... "
+      FileUtils.remove_dir(rm_dir, true)
+      puts "OK"
+    end
+
+    FileUtils.mkdir("#{gem_dir}/app/assets/images")
+
+    {
+      'source/_patterns' => 'app/views',
+      'source/sass' => 'app/assets/stylesheets',
+      'source/js/modules' => 'app/assets/javascripts',
+      'source/images/*.png' => 'app/assets/images',
+      'source/images/*.gif' => 'app/assets/images',
+      'source/images/*.jpg' => 'app/assets/images',
+      'source/images/*.svg' => 'app/assets/images',
+      'source/images/favicons' => 'app/assets/images',
+      'source/images/icons' => 'app/assets/images'
+    }.each do |from, to|
+      cp_src = "#{patternlab_dir}/#{from}"
+      cp_dst = "#{gem_dir}/#{to}"
+      print "Copying files from #{cp_src} to #{cp_dst}... "
+      cp_src = Dir.glob(cp_src) if from.include?('*')
+      FileUtils.cp_r(cp_src, cp_dst)
+      puts "OK"
+    end
+  end
+end


### PR DESCRIPTION
Use:
```
bundle exec rake europeana_styleguide:populate[../Europeana-Patternlab]
```
... assuming that the cloned PatternLab repository is in the directory ../Europeana-Patternab.
